### PR TITLE
ringdht: Refactoring the ringaccount class

### DIFF
--- a/src/ringdht/Makefile.am
+++ b/src/ringdht/Makefile.am
@@ -16,12 +16,15 @@ libringacc_la_LIBADD = $(DHT_LIBS) \
     ./eth/libdevcrypto/libdevcrypto.la
 
 libringacc_la_SOURCES = \
+	contact.h \
+	contactsmanager.cpp \
+	contactsmanager.h \
         ringaccount.cpp \
         ringaccount.h \
         sip_transport_ice.cpp \
         sip_transport_ice.h \
         sips_transport_ice.cpp \
-        sips_transport_ice.h
+        sips_transport_ice.h 
 
 if RINGNS
 libringacc_la_SOURCES += \

--- a/src/ringdht/contact.h
+++ b/src/ringdht/contact.h
@@ -1,3 +1,23 @@
+/*
+*  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
+*  Author: Hana Ben Arab <hana.ben-arab@polymtl.ca>
+*  Author: Abderrahmane Laribi <abderrahmane.laribi@polymtl.ca>
+*  Author: Sonia Farrah <sonia.farrah@polymtl.ca>
+*  Author: Ahmed Belhaouane <ahmed.belhaouane@polymtl.ca>
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with this program; if not, write to the Free Software
+*  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
+*/
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/src/ringdht/contact.h
+++ b/src/ringdht/contact.h
@@ -1,0 +1,85 @@
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <json/json.h>
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <sstream>
+#include <cctype>
+#include <cstdarg>
+#include <string>
+#include <fstream>
+
+#include "string_utils.h"
+#include "logger.h"
+#include "fileutils.h"
+namespace ring {
+	class Contact
+	{
+	public:
+		/** Time of contact addition */
+		time_t added{ 0 };
+
+		/** Time of contact removal */
+		time_t removed{ 0 };
+
+		/** True if we got confirmation that this contact also added us */
+		bool confirmed{ false };
+
+		/** True if the contact is banned (if not active) */
+		bool banned{ false };
+
+		/** True if the contact is an active contact (not banned nor removed) */
+		bool isActive() const { return added > removed; }
+		bool isBanned() const { return not isActive() and banned; }
+
+		Contact() = default;
+		Contact(const Json::Value& json) {
+			added = json["added"].asInt();
+			removed = json["removed"].asInt();
+			confirmed = json["confirmed"].asBool();
+			banned = json["banned"].asBool();
+		}
+
+		/**
+		* Update this contact using other known contact information,
+		* return true if contact state was changed.
+		*/
+		bool update(const Contact& c) {
+			const auto copy = *this;
+			if (c.added > added) {
+				added = c.added;
+			}
+			if (c.removed > removed) {
+				removed = c.removed;
+				banned = c.banned;
+			}
+			if (c.confirmed != confirmed) {
+				confirmed = c.confirmed or confirmed;
+			}
+			return hasSameState(copy);
+		}
+		bool hasSameState(const Contact& other) const {
+			return other.isActive() != isActive()
+				or other.isBanned() != isBanned()
+				or other.confirmed != confirmed;
+		}
+
+		Json::Value toJson() const {
+			Json::Value json;
+			json["added"] = Json::Int64(added);
+			json["removed"] = Json::Int64(removed);
+			json["confirmed"] = confirmed;
+			json["banned"] = banned;
+			return json;
+		}
+
+		MSGPACK_DEFINE_MAP(added, removed, confirmed, banned)
+
+	};
+}

--- a/src/ringdht/contactsmanager.cpp
+++ b/src/ringdht/contactsmanager.cpp
@@ -1,0 +1,131 @@
+
+#include "contactsmanager.h"
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <json/json.h>
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <sstream>
+#include <cctype>
+#include <cstdarg>
+#include <string>
+#include <fstream>
+
+#include "string_utils.h"
+#include "logger.h"
+#include "fileutils.h"
+
+#include "contact.h"
+#include <typeinfo>
+namespace ring {
+
+
+ContactsManager::ContactsManager(const std::string& accountID) 
+	: accountID_ (accountID) ,idPath_(fileutils::get_data_dir()+DIR_SEPARATOR_STR+accountID){
+
+}
+
+Contact
+ContactsManager::addContact(const std::string& uri, bool confirmed)
+{
+    dht::InfoHash h (uri);
+    auto c = contacts_.find(h);
+    if (c == contacts_.end())
+        c = contacts_.emplace(h, Contact{}).first;
+    else if (c->second.isActive() and c->second.confirmed == confirmed)
+        return c->second;
+    c->second.added = std::time(nullptr);
+    c->second.confirmed = confirmed or c->second.confirmed;
+	return c->second;
+}
+
+Contact
+ContactsManager::removeContact(const std::string& uri, bool ban)
+{
+    dht::InfoHash h (uri);
+    auto c = contacts_.find(h);
+    if (c == contacts_.end())
+        c = contacts_.emplace(h, Contact{}).first;
+    else if (not c->second.isActive() and c->second.banned == ban)
+        return c->second;
+    c->second.removed = std::time(nullptr);
+    c->second.banned = ban;
+    return c->second;
+    }
+
+
+std::vector<std::map<std::string, std::string>>
+ContactsManager::getContacts() const
+{
+    std::vector<std::map<std::string, std::string>> ret;
+    ret.reserve(contacts_.size());
+    for (const auto& c : contacts_) {
+        if (not (c.second.isActive() or c.second.isBanned()))
+            continue;
+        std::map<std::string, std::string> cm {
+            {"id", c.first.toString()},
+            {"added", std::to_string(c.second.added)}
+        };
+        if (c.second.isActive())
+            cm.emplace("confirmed", c.second.confirmed ? TRUE_STR : FALSE_STR);
+        else if (c.second.isBanned())
+            cm.emplace("banned", TRUE_STR);
+        ret.emplace_back(std::move(cm));
+    }
+    return ret;
+}
+
+bool
+ContactsManager::updateContact(const dht::InfoHash& id, const Contact& contact, Contact& returnedContact)
+{
+
+    bool stateChanged {false};
+    auto c = contacts_.find(id);
+	
+    if (c == contacts_.end()) {
+        RING_DBG("[Account %s] new contact: %s",accountID_ , id.toString().c_str());
+        c = contacts_.emplace(id, contact).first;
+        stateChanged = c->second.isActive() or c->second.isBanned();
+    } else {
+        RING_DBG("[Account %s] updated contact: %s", accountID_, id.toString().c_str());
+        stateChanged = c->second.update(contact);
+    }
+	
+	returnedContact = c->second;
+    
+	return stateChanged;
+}
+
+void
+ContactsManager::loadContacts()
+{
+    decltype(contacts_) contacts;
+    try {
+        // read file
+        auto file = fileutils::loadFile("contacts", idPath_);
+        // load values
+        msgpack::object_handle oh = msgpack::unpack((const char*)file.data(), file.size());
+        oh.get().convert(contacts);
+    } catch (const std::exception& e) {
+        RING_WARN("[Account %s] error loading contacts: %s", accountID_, e.what());
+        return;
+    }
+	Contact contactToReturn;
+    for (auto& peer : contacts)
+        updateContact(peer.first, peer.second,contactToReturn);
+}
+
+void
+ContactsManager::saveContacts() const
+{
+    std::ofstream file(idPath_+DIR_SEPARATOR_STR "contacts", std::ios::trunc | std::ios::binary);
+    msgpack::pack(file, contacts_);
+}
+
+}

--- a/src/ringdht/contactsmanager.h
+++ b/src/ringdht/contactsmanager.h
@@ -1,0 +1,67 @@
+/*
+*  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
+*
+*  Author: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+*  Author: Simon Désaulniers <simon.desaulniers@gmail.com>
+*
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with this program; if not, write to the Free Software
+*  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
+*/
+
+#pragma once
+
+#include <opendht/dhtrunner.h>
+#include <opendht/default_types.h>
+
+#include <vector>
+#include <map>
+#include <chrono>
+#include <list>
+#include <future>
+
+/**
+* @file contactsmanager.h
+* @brief Contacts Manager is used by Ring Account to handle contacts operations
+*/
+
+
+namespace ring {
+
+	class Contact;
+	class ContactsManager {
+
+	private:
+		std::string accountID_;
+		std::string idPath_{};
+
+	public:
+		ContactsManager(const std::string& accountID);
+
+
+
+		std::map<dht::InfoHash, Contact> contacts_;
+		void loadContacts();
+		void saveContacts() const;
+		bool updateContact(const dht::InfoHash&, const Contact&, Contact& returnedContact);
+
+		/**
+		* Add contact to the account contact list.
+		* Set confirmed if we know the contact also added us.
+		*/
+		Contact addContact(const std::string& uri, bool confirmed = false);
+		Contact removeContact(const std::string& uri, bool banned = true);
+		std::vector<std::map<std::string, std::string>> getContacts() const;
+
+	};
+}

--- a/src/ringdht/contactsmanager.h
+++ b/src/ringdht/contactsmanager.h
@@ -1,9 +1,9 @@
 /*
 *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
-*
-*  Author: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
-*  Author: Simon Désaulniers <simon.desaulniers@gmail.com>
-*
+*  Author: Hana Ben Arab <hana.ben-arab@polymtl.ca>
+*  Author: Abderrahmane Laribi <abderrahmane.laribi@polymtl.ca>
+*  Author: Sonia Farrah <sonia.farrah@polymtl.ca>
+*  Author: Ahmed Belhaouane <ahmed.belhaouane@polymtl.ca>
 *  This program is free software; you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by
 *  the Free Software Foundation; either version 3 of the License, or

--- a/src/ringdht/ringaccount.h
+++ b/src/ringdht/ringaccount.h
@@ -1,23 +1,23 @@
 /*
- *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
- *
- *  Author: Adrien BÃ©raud <adrien.beraud@savoirfairelinux.com>
- *  Author: Simon DÃ©saulniers <simon.desaulniers@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
- */
+*  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
+*
+*  Author: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+*  Author: Simon Désaulniers <simon.desaulniers@gmail.com>
+*
+*  This program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with this program; if not, write to the Free Software
+*  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
+*/
 
 #pragma once
 
@@ -27,6 +27,8 @@
 
 #include "security/tls_session.h"
 #include "sip/sipaccountbase.h"
+
+#include "contactsmanager.h"
 
 #include "noncopyable.h"
 #include "ip_utils.h"
@@ -46,540 +48,551 @@
 #if HAVE_RINGNS
 #include "namedirectory.h"
 #endif
-
+#include "contact.h"
 /**
- * @file ringaccount.h
- * @brief Ring Account is build on top of SIPAccountBase and uses DHT to handle call connectivity.
- */
+* @file ringaccount.h
+* @brief Ring Account is build on top of SIPAccountBase and uses DHT to handle call connectivity.
+*/
 
 namespace YAML {
-class Node;
-class Emitter;
+	class Node;
+	class Emitter;
 }
 
 
 namespace dev
 {
-    template <unsigned N> class FixedHash;
-    using h160 = FixedHash<20>;
-    using Address = h160;
+	template <unsigned N> class FixedHash;
+	using h160 = FixedHash<20>;
+	using Address = h160;
 }
 
 namespace ring {
 
-namespace Conf {
-constexpr const char* const DHT_PORT_KEY = "dhtPort";
-constexpr const char* const DHT_VALUES_PATH_KEY = "dhtValuesPath";
-constexpr const char* const DHT_CONTACTS = "dhtContacts";
-constexpr const char* const DHT_PUBLIC_PROFILE = "dhtPublicProfile";
-constexpr const char* const DHT_PUBLIC_IN_CALLS = "dhtPublicInCalls";
-constexpr const char* const DHT_ALLOW_PEERS_FROM_HISTORY = "allowPeersFromHistory";
-constexpr const char* const DHT_ALLOW_PEERS_FROM_CONTACT = "allowPeersFromContact";
-constexpr const char* const DHT_ALLOW_PEERS_FROM_TRUSTED = "allowPeersFromTrusted";
-constexpr const char* const ETH_KEY = "ethKey";
-constexpr const char* const ETH_PATH = "ethPath";
-constexpr const char* const ETH_ACCOUNT = "ethAccount";
-constexpr const char* const RING_CA_KEY = "ringCaKey";
-constexpr const char* const RING_ACCOUNT_KEY = "ringAccountKey";
-constexpr const char* const RING_ACCOUNT_CERT = "ringAccountCert";
-constexpr const char* const RING_ACCOUNT_RECEIPT = "ringAccountReceipt";
-constexpr const char* const RING_ACCOUNT_RECEIPT_SIG = "ringAccountReceiptSignature";
-constexpr const char* const RING_ACCOUNT_CRL = "ringAccountCRL";
-constexpr const char* const RING_ACCOUNT_CONTACTS = "ringAccountContacts";
-}
+	namespace Conf {
+		constexpr const char* const DHT_PORT_KEY = "dhtPort";
+		constexpr const char* const DHT_VALUES_PATH_KEY = "dhtValuesPath";
+		constexpr const char* const DHT_CONTACTS = "dhtContacts";
+		constexpr const char* const DHT_PUBLIC_PROFILE = "dhtPublicProfile";
+		constexpr const char* const DHT_PUBLIC_IN_CALLS = "dhtPublicInCalls";
+		constexpr const char* const DHT_ALLOW_PEERS_FROM_HISTORY = "allowPeersFromHistory";
+		constexpr const char* const DHT_ALLOW_PEERS_FROM_CONTACT = "allowPeersFromContact";
+		constexpr const char* const DHT_ALLOW_PEERS_FROM_TRUSTED = "allowPeersFromTrusted";
+		constexpr const char* const ETH_KEY = "ethKey";
+		constexpr const char* const ETH_PATH = "ethPath";
+		constexpr const char* const ETH_ACCOUNT = "ethAccount";
+		constexpr const char* const RING_CA_KEY = "ringCaKey";
+		constexpr const char* const RING_ACCOUNT_KEY = "ringAccountKey";
+		constexpr const char* const RING_ACCOUNT_CERT = "ringAccountCert";
+		constexpr const char* const RING_ACCOUNT_RECEIPT = "ringAccountReceipt";
+		constexpr const char* const RING_ACCOUNT_RECEIPT_SIG = "ringAccountReceiptSignature";
+		constexpr const char* const RING_ACCOUNT_CRL = "ringAccountCRL";
+		constexpr const char* const RING_ACCOUNT_CONTACTS = "ringAccountContacts";
+	}
 
-class IceTransport;
+	class IceTransport;
+	//class ContactsManager;
 
-class RingAccount : public SIPAccountBase {
-    public:
-        constexpr static const char* const ACCOUNT_TYPE = "RING";
-        constexpr static const in_port_t DHT_DEFAULT_PORT = 4222;
-        constexpr static const char* const DHT_DEFAULT_BOOTSTRAP = "bootstrap.ring.cx";
-        constexpr static const char* const DHT_TYPE_NS = "cx.ring";
+	class RingAccount : public SIPAccountBase {
+	public:
+		constexpr static const char* const ACCOUNT_TYPE = "RING";
+		constexpr static const in_port_t DHT_DEFAULT_PORT = 4222;
+		constexpr static const char* const DHT_DEFAULT_BOOTSTRAP = "bootstrap.ring.cx";
+		constexpr static const char* const DHT_TYPE_NS = "cx.ring";
 
-        /* constexpr */ static const std::pair<uint16_t, uint16_t> DHT_PORT_RANGE;
+		/* constexpr */ static const std::pair<uint16_t, uint16_t> DHT_PORT_RANGE;
 
-        const char* getAccountType() const override {
-            return ACCOUNT_TYPE;
-        }
+		const char* getAccountType() const override {
+			return ACCOUNT_TYPE;
+		}
 
-        std::shared_ptr<RingAccount> shared() {
-            return std::static_pointer_cast<RingAccount>(shared_from_this());
-        }
-        std::shared_ptr<RingAccount const> shared() const {
-            return std::static_pointer_cast<RingAccount const>(shared_from_this());
-        }
+		std::shared_ptr<RingAccount> shared() {
+			return std::static_pointer_cast<RingAccount>(shared_from_this());
+		}
+		std::shared_ptr<RingAccount const> shared() const {
+			return std::static_pointer_cast<RingAccount const>(shared_from_this());
+		}
 
-        /**
-         * Constructor
-         * @param accountID The account identifier
-         */
-        RingAccount(const std::string& accountID, bool presenceEnabled);
+		/**
+		* Constructor
+		* @param accountID The account identifier
+		*/
+		RingAccount(const std::string& accountID, bool presenceEnabled);
 
-        ~RingAccount();
+		~RingAccount();
 
-        /**
-         * Serialize internal state of this account for configuration
-         * @param YamlEmitter the configuration engine which generate the configuration file
-         */
-        virtual void serialize(YAML::Emitter &out) override;
+		/**
+		* Serialize internal state of this account for configuration
+		* @param YamlEmitter the configuration engine which generate the configuration file
+		*/
+		virtual void serialize(YAML::Emitter &out) override;
 
-        /**
-         * Populate the internal state for this account based on info stored in the configuration file
-         * @param The configuration node for this account
-         */
-        virtual void unserialize(const YAML::Node &node) override;
+		/**
+		* Populate the internal state for this account based on info stored in the configuration file
+		* @param The configuration node for this account
+		*/
+		virtual void unserialize(const YAML::Node &node) override;
 
-        /**
-         * Return an map containing the internal state of this account. Client application can use this method to manage
-         * account info.
-         * @return A map containing the account information.
-         */
-        virtual std::map<std::string, std::string> getAccountDetails() const override;
+		/**
+		* Return an map containing the internal state of this account. Client application can use this method to manage
+		* account info.
+		* @return A map containing the account information.
+		*/
+		virtual std::map<std::string, std::string> getAccountDetails() const override;
 
-        /**
-         * Retrieve volatile details such as recent registration errors
-         * @return std::map< std::string, std::string > The account volatile details
-         */
-        virtual std::map<std::string, std::string> getVolatileAccountDetails() const override;
+		/**
+		* Retrieve volatile details such as recent registration errors
+		* @return std::map< std::string, std::string > The account volatile details
+		*/
+		virtual std::map<std::string, std::string> getVolatileAccountDetails() const override;
 
-        /**
-         * Actually useless, since config loading is done in init()
-         */
-        void loadConfig() override {}
+		/**
+		* Actually useless, since config loading is done in init()
+		*/
+		void loadConfig() override {}
 
-        /**
-         * Adds an account id to the list of accounts to track on the DHT for
-         * buddy presence.
-         *
-         * @param buddy_id  The buddy id.
-         */
-        void trackBuddyPresence(const std::string& buddy_id);
+		/**
+		* Adds an account id to the list of accounts to track on the DHT for
+		* buddy presence.
+		*
+		* @param buddy_id  The buddy id.
+		*/
+		void trackBuddyPresence(const std::string& buddy_id);
 
-        /**
-         * Tells for each tracked account id if it has been seen online so far
-         * in the last DeviceAnnouncement::TYPE.expiration minutes.
-         *
-         * @return map of buddy_uri to bool (online or not)
-         */
-        std::map<std::string, bool> getTrackedBuddyPresence();
+		/**
+		* Tells for each tracked account id if it has been seen online so far
+		* in the last DeviceAnnouncement::TYPE.expiration minutes.
+		*
+		* @return map of buddy_uri to bool (online or not)
+		*/
+		std::map<std::string, bool> getTrackedBuddyPresence();
 
-        /**
-         * Connect to the DHT.
-         */
-        void doRegister() override;
+		/**
+		* Connect to the DHT.
+		*/
+		void doRegister() override;
 
-        /**
-         * Disconnect from the DHT.
-         */
-        void doUnregister(std::function<void(bool)> cb = {}) override;
+		/**
+		* Disconnect from the DHT.
+		*/
+		void doUnregister(std::function<void(bool)> cb = {}) override;
 
-        /**
-         * @return pj_str_t "From" uri based on account information.
-         * From RFC3261: "The To header field first and foremost specifies the desired
-         * logical" recipient of the request, or the address-of-record of the
-         * user or resource that is the target of this request. [...]  As such, it is
-         * very important that the From URI not contain IP addresses or the FQDN
-         * of the host on which the UA is running, since these are not logical
-         * names."
-         */
-        std::string getFromUri() const;
+		/**
+		* @return pj_str_t "From" uri based on account information.
+		* From RFC3261: "The To header field first and foremost specifies the desired
+		* logical" recipient of the request, or the address-of-record of the
+		* user or resource that is the target of this request. [...]  As such, it is
+		* very important that the From URI not contain IP addresses or the FQDN
+		* of the host on which the UA is running, since these are not logical
+		* names."
+		*/
+		std::string getFromUri() const;
 
-        /**
-         * This method adds the correct scheme, hostname and append
-         * the ;transport= parameter at the end of the uri, in accordance with RFC3261.
-         * It is expected that "port" is present in the internal hostname_.
-         *
-         * @return pj_str_t "To" uri based on @param username
-         * @param username A string formatted as : "username"
-         */
-        std::string getToUri(const std::string& username) const override;
+		/**
+		* This method adds the correct scheme, hostname and append
+		* the ;transport= parameter at the end of the uri, in accordance with RFC3261.
+		* It is expected that "port" is present in the internal hostname_.
+		*
+		* @return pj_str_t "To" uri based on @param username
+		* @param username A string formatted as : "username"
+		*/
+		std::string getToUri(const std::string& username) const override;
 
-        /**
-         * In the current version of Ring, "srv" uri is obtained in the preformated
-         * way: hostname:port. This method adds the correct scheme and append
-         * the ;transport= parameter at the end of the uri, in accordance with RFC3261.
-         *
-         * @return pj_str_t "server" uri based on @param hostPort
-         * @param hostPort A string formatted as : "hostname:port"
-         */
-        std::string getServerUri() const { return ""; };
+		/**
+		* In the current version of Ring, "srv" uri is obtained in the preformated
+		* way: hostname:port. This method adds the correct scheme and append
+		* the ;transport= parameter at the end of the uri, in accordance with RFC3261.
+		*
+		* @return pj_str_t "server" uri based on @param hostPort
+		* @param hostPort A string formatted as : "hostname:port"
+		*/
+		std::string getServerUri() const { return ""; };
 
-        /**
-         * Get the contact header for
-         * @return pj_str_t The contact header based on account information
-         */
-        pj_str_t getContactHeader(pjsip_transport* = nullptr) override;
+		/**
+		* Get the contact header for
+		* @return pj_str_t The contact header based on account information
+		*/
+		pj_str_t getContactHeader(pjsip_transport* = nullptr) override;
 
-        void setReceivedParameter(const std::string &received) {
-            receivedParameter_ = received;
-            via_addr_.host.ptr = (char *) receivedParameter_.c_str();
-            via_addr_.host.slen = receivedParameter_.size();
-        }
+		void setReceivedParameter(const std::string &received) {
+			receivedParameter_ = received;
+			via_addr_.host.ptr = (char *)receivedParameter_.c_str();
+			via_addr_.host.slen = receivedParameter_.size();
+		}
 
-        std::string getReceivedParameter() const {
-            return receivedParameter_;
-        }
+		std::string getReceivedParameter() const {
+			return receivedParameter_;
+		}
 
-        pjsip_host_port *
-        getViaAddr() {
-            return &via_addr_;
-        }
+		pjsip_host_port *
+			getViaAddr() {
+			return &via_addr_;
+		}
 
-        /* Returns true if the username and/or hostname match this account */
-        MatchRank matches(const std::string &username, const std::string &hostname) const override;
+		/* Returns true if the username and/or hostname match this account */
+		MatchRank matches(const std::string &username, const std::string &hostname) const override;
 
-        /**
-         * Implementation of Account::newOutgoingCall()
-         * Note: keep declaration before newOutgoingCall template.
-         */
-        std::shared_ptr<Call> newOutgoingCall(const std::string& toUrl) override;
+		/**
+		* Implementation of Account::newOutgoingCall()
+		* Note: keep declaration before newOutgoingCall template.
+		*/
+		std::shared_ptr<Call> newOutgoingCall(const std::string& toUrl) override;
 
-        /**
-         * Create outgoing SIPCall.
-         * @param[in] toUrl The address to call
-         * @return std::shared_ptr<T> A shared pointer on the created call.
-         *      The type of this instance is given in template argument.
-         *      This type can be any base class of SIPCall class (included).
-         */
+		/**
+		* Create outgoing SIPCall.
+		* @param[in] toUrl The address to call
+		* @return std::shared_ptr<T> A shared pointer on the created call.
+		*      The type of this instance is given in template argument.
+		*      This type can be any base class of SIPCall class (included).
+		*/
 #ifndef RING_UWP
-        template <class T=SIPCall>
-        std::shared_ptr<enable_if_base_of<T, SIPCall> >
-        newOutgoingCall(const std::string& toUrl);
+		template <class T = SIPCall>
+		std::shared_ptr<enable_if_base_of<T, SIPCall> >
+			newOutgoingCall(const std::string& toUrl);
 #else
-        template <class T>
-        std::shared_ptr<T>
-        newOutgoingCall(const std::string& toUrl);
+		template <class T>
+		std::shared_ptr<T>
+			newOutgoingCall(const std::string& toUrl);
 #endif
 
-        /**
-         * Create incoming SIPCall.
-         * @param[in] from The origin of the call
-         * @return std::shared_ptr<T> A shared pointer on the created call.
-         *      The type of this instance is given in template argument.
-         *      This type can be any base class of SIPCall class (included).
-         */
-        virtual std::shared_ptr<SIPCall>
-        newIncomingCall(const std::string& from = {}) override;
+		/**
+		* Create incoming SIPCall.
+		* @param[in] from The origin of the call
+		* @return std::shared_ptr<T> A shared pointer on the created call.
+		*      The type of this instance is given in template argument.
+		*      This type can be any base class of SIPCall class (included).
+		*/
+		virtual std::shared_ptr<SIPCall>
+			newIncomingCall(const std::string& from = {}) override;
 
-        virtual bool isTlsEnabled() const override {
-            return true;
-        }
+		virtual bool isTlsEnabled() const override {
+			return true;
+		}
 
-        virtual bool isSrtpEnabled() const {
-            return true;
-        }
+		virtual bool isSrtpEnabled() const {
+			return true;
+		}
 
-        virtual sip_utils::KeyExchangeProtocol getSrtpKeyExchange() const override {
-            return sip_utils::KeyExchangeProtocol::SDES;
-        }
+		virtual sip_utils::KeyExchangeProtocol getSrtpKeyExchange() const override {
+			return sip_utils::KeyExchangeProtocol::SDES;
+		}
 
-        virtual bool getSrtpFallback() const override {
-            return false;
-        }
+		virtual bool getSrtpFallback() const override {
+			return false;
+		}
 
-        bool setCertificateStatus(const std::string& cert_id, tls::TrustStore::PermissionStatus status);
-        bool setCertificateStatus(const std::string& cert_id, tls::TrustStatus status);
+		bool setCertificateStatus(const std::string& cert_id, tls::TrustStore::PermissionStatus status);
+		bool setCertificateStatus(const std::string& cert_id, tls::TrustStatus status);
 
-        std::vector<std::string> getCertificatesByStatus(tls::TrustStore::PermissionStatus status);
+		std::vector<std::string> getCertificatesByStatus(tls::TrustStore::PermissionStatus status);
 
-        bool findCertificate(const std::string& id);
-        bool findCertificate(const dht::InfoHash& h, std::function<void(const std::shared_ptr<dht::crypto::Certificate>&)>&& cb = {});
+		bool findCertificate(const std::string& id);
+		bool findCertificate(const dht::InfoHash& h, std::function<void(const std::shared_ptr<dht::crypto::Certificate>&)>&& cb = {});
 
-        /* contact requests */
-        std::map<std::string, std::string> getTrustRequests() const;
-        bool acceptTrustRequest(const std::string& from);
-        bool discardTrustRequest(const std::string& from);
+		/* contact requests */
+		std::vector<std::map<std::string, std::string>> getTrustRequests() const;
+		bool acceptTrustRequest(const std::string& from);
+		bool discardTrustRequest(const std::string& from);
 
-        /**
-         * Add contact to the account contact list.
-         * Set confirmed if we know the contact also added us.
-         */
-        void addContact(const std::string& uri, bool confirmed = false);
-        void removeContact(const std::string& uri);
-        std::vector<std::map<std::string, std::string>> getContacts() const;
+		/**
+		* Add contact to the account contact list.
+		* Set confirmed if we know the contact also added us.
+		*/
+		void addContact(const std::string& uri, bool confirmed = false);
+		void removeContact(const std::string& uri, bool banned = true);
+		std::vector<std::map<std::string, std::string>> getContacts() const;
 
-        void sendTrustRequest(const std::string& to, const std::vector<uint8_t>& payload);
-        void sendTrustRequestConfirm(const dht::InfoHash& to);
-        virtual void sendTextMessage(const std::string& to, const std::map<std::string, std::string>& payloads, uint64_t id) override;
+		void sendTrustRequest(const std::string& to, const std::vector<uint8_t>& payload);
+		void sendTrustRequestConfirm(const dht::InfoHash& to);
+		virtual void sendTextMessage(const std::string& to, const std::map<std::string, std::string>& payloads, uint64_t id) override;
 
-        void addDevice(const std::string& password);
+		void addDevice(const std::string& password);
 
-        bool revokeDevice(const std::string& password, const std::string& device);
+		bool revokeDevice(const std::string& password, const std::string& device);
 
-        std::map<std::string, std::string> getKnownDevices() const;
+		std::map<std::string, std::string> getKnownDevices() const;
 
-        void connectivityChanged() override;
+		void connectivityChanged() override;
 
-        // overloaded methods
-        void flush() override;
+		// overloaded methods
+		void flush() override;
 
 #if HAVE_RINGNS
-        void lookupName(const std::string& name);
-        void lookupAddress(const std::string& address);
-        void registerName(const std::string& password, const std::string& name);
+		void lookupName(const std::string& name);
+		void lookupAddress(const std::string& address);
+		void registerName(const std::string& password, const std::string& name);
 #endif
 
-    private:
-        NON_COPYABLE(RingAccount);
+	private:
+		NON_COPYABLE(RingAccount);
 
-        /**
-         * Private structures
-         */
-        struct PendingCall;
-        struct PendingMessage;
-        struct SavedTrustRequest;
-        struct TrustRequest;
-        struct KnownDevice;
-        struct ArchiveContent;
-        struct DeviceAnnouncement;
-        struct DeviceSync;
-        struct BuddyInfo;
-        struct Contact;
+		using clock = std::chrono::system_clock;
+		using time_point = clock::time_point;
 
-        void syncDevices();
-        void onReceiveDeviceSync(DeviceSync&& sync);
+		/**
+		* Private structures
+		*/
+		struct PendingCall;
+		struct PendingMessage;
+		struct TrustRequest;
+		struct KnownDevice;
+		struct ArchiveContent;
+		struct DeviceAnnouncement;
+		struct DeviceSync;
+		struct BuddyInfo;
+		//struct Contact;
+
+		void syncDevices();
+		void onReceiveDeviceSync(DeviceSync&& sync);
 
 #if HAVE_RINGNS
-        std::reference_wrapper<NameDirectory> nameDir_;
-        std::string nameServer_;
-        std::string registeredName_;
+		std::reference_wrapper<NameDirectory> nameDir_;
+		std::string nameServer_;
+		std::string registeredName_;
 #endif
 
-        /**
-         * Compute archive encryption key and DHT storage location from password and PIN.
-         */
-        static std::pair<std::vector<uint8_t>, dht::InfoHash> computeKeys(const std::string& password, const std::string& pin, bool previous=false);
+		/**
+		* Compute archive encryption key and DHT storage location from password and PIN.
+		*/
+		static std::pair<std::vector<uint8_t>, dht::InfoHash> computeKeys(const std::string& password, const std::string& pin, bool previous = false);
 
-        /**
-         * Update tracking info when buddy appears offline.
-         *
-         * @param buddy_info_it  An iterator over the map trackedBuddies_
-         */
-        void onTrackedBuddyOffline(std::map<dht::InfoHash, BuddyInfo>::iterator& buddy_info_it);
+		/**
+		* Update tracking info when buddy appears offline.
+		*
+		* @param buddy_info_it  An iterator over the map trackedBuddies_
+		*/
+		void onTrackedBuddyOffline(std::map<dht::InfoHash, BuddyInfo>::iterator& buddy_info_it);
 
-        /**
-         * Update tracking info when buddy appears offline.
-         *
-         * @param buddy_info_it  An iterator over the map trackedBuddies_
-         * @param device_id       The device id
-         */
-        void onTrackedBuddyOnline(std::map<dht::InfoHash, BuddyInfo>::iterator& buddy_info_it, const dht::InfoHash& device_id);
+		/**
+		* Update tracking info when buddy appears offline.
+		*
+		* @param buddy_info_it  An iterator over the map trackedBuddies_
+		* @param device_id       The device id
+		*/
+		void onTrackedBuddyOnline(std::map<dht::InfoHash, BuddyInfo>::iterator& buddy_info_it, const dht::InfoHash& device_id);
 
-        void doRegister_();
-        void incomingCall(dht::IceCandidates&& msg, const std::shared_ptr<dht::crypto::Certificate>& from);
+		void doRegister_();
+		void incomingCall(dht::IceCandidates&& msg, const std::shared_ptr<dht::crypto::Certificate>& from);
 
-        const dht::ValueType USER_PROFILE_TYPE = {9, "User profile", std::chrono::hours(24 * 7)};
+		const dht::ValueType USER_PROFILE_TYPE = { 9, "User profile", std::chrono::hours(24 * 7) };
 
-        void handleEvents();
+		void handleEvents();
 
-        void forEachDevice(const dht::InfoHash& to, std::function<void(const std::shared_ptr<RingAccount>&, const dht::InfoHash&)> op, std::function<void(bool)> end = {});
+		void forEachDevice(const dht::InfoHash& to, std::function<void(const std::shared_ptr<RingAccount>&, const dht::InfoHash&)> op, std::function<void(bool)> end = {});
 
-        void createOutgoingCall(const std::shared_ptr<SIPCall>& call, const std::string& to_id, IpAddr target);
+		void createOutgoingCall(const std::shared_ptr<SIPCall>& call, const std::string& to_id, IpAddr target);
 
-        /**
-         * Set the internal state for this account, mainly used to manage account details from the client application.
-         * @param The map containing the account information.
-         */
-        virtual void setAccountDetails(const std::map<std::string, std::string> &details) override;
+		/**
+		* Set the internal state for this account, mainly used to manage account details from the client application.
+		* @param The map containing the account information.
+		*/
+		virtual void setAccountDetails(const std::map<std::string, std::string> &details) override;
 
-        void startOutgoingCall(const std::shared_ptr<SIPCall>& call, const std::string toUri);
+		void startOutgoingCall(const std::shared_ptr<SIPCall>& call, const std::string toUri);
 
-        /**
-         * Start a SIP Call
-         * @param call  The current call
-         * @return true if all is correct
-         */
-        bool SIPStartCall(const std::shared_ptr<SIPCall>& call, IpAddr target);
+		/**
+		* Start a SIP Call
+		* @param call  The current call
+		* @return true if all is correct
+		*/
+		bool SIPStartCall(const std::shared_ptr<SIPCall>& call, IpAddr target);
 
-        /**
-         * Inform that a potential account device have been found.
-         * Returns true if the device have been validated to be part of this account
-         */
-        bool foundAccountDevice(const std::shared_ptr<dht::crypto::Certificate>& crt, const std::string& name = {});
+		/**
+		* Inform that a potential account device have been found.
+		* Returns true if the device have been validated to be part of this account
+		*/
+		bool foundAccountDevice(const std::shared_ptr<dht::crypto::Certificate>& crt, const std::string& name = {}, const time_point& last_sync = time_point::min());
 
-        /**
-         * Inform that a potential peer device have been found.
-         * Returns true only if the device certificate is a valid Ring device certificate.
-         * In that case (true is returned) the account_id parameter is set to the peer account ID.
-         */
-        bool foundPeerDevice(const std::shared_ptr<dht::crypto::Certificate>& crt, dht::InfoHash& account_id);
+		/**
+		* Inform that a potential peer device have been found.
+		* Returns true only if the device certificate is a valid Ring device certificate.
+		* In that case (true is returned) the account_id parameter is set to the peer account ID.
+		*/
+		bool foundPeerDevice(const std::shared_ptr<dht::crypto::Certificate>& crt, dht::InfoHash& account_id);
 
-        /**
-         * Check that a peer is authorised to talk to us.
-         * If everything is in order, calls the callback with the
-         * peer certificate chain (down to the peer device certificate),
-         * and the peer account id.
-         */
-        void onPeerMessage(const dht::InfoHash& peer_device, std::function<void(const std::shared_ptr<dht::crypto::Certificate>& crt, const dht::InfoHash& account_id)>);
+		/**
+		* Check that a peer is authorised to talk to us.
+		* If everything is in order, calls the callback with the
+		* peer certificate chain (down to the peer device certificate),
+		* and the peer account id.
+		*/
+		void onPeerMessage(const dht::InfoHash& peer_device, std::function<void(const std::shared_ptr<dht::crypto::Certificate>& crt, const dht::InfoHash& account_id)>);
 
-        /**
-         * Maps require port via UPnP
-         */
-        bool mapPortUPnP();
+		void onTrustRequest(const dht::InfoHash& peer_account, const dht::InfoHash& peer_device, time_t received, bool confirm, std::vector<uint8_t>&& payload);
 
-        void igdChanged();
+		/**
+		* Maps require port via UPnP
+		*/
+		bool mapPortUPnP();
 
-        dht::DhtRunner dht_ {};
-        dht::crypto::Identity identity_ {};
+		void igdChanged();
 
-        dht::InfoHash callKey_;
+		dht::DhtRunner dht_{};
+		dht::crypto::Identity identity_{};
 
-        void handlePendingCallList();
-        bool handlePendingCall(PendingCall& pc, bool incoming);
+		dht::InfoHash callKey_;
 
-        /**
-         * DHT calls waiting for ICE negotiation
-         */
-        std::list<PendingCall> pendingCalls_;
+		void handlePendingCallList();
+		bool handlePendingCall(PendingCall& pc, bool incoming);
 
-        /**
-         * Incoming DHT calls that are not yet actual SIP calls.
-         */
-        std::list<PendingCall> pendingSipCalls_;
-        std::set<dht::Value::Id> treatedCalls_ {};
-        mutable std::mutex callsMutex_ {};
+		/**
+		* DHT calls waiting for ICE negotiation
+		*/
+		std::list<PendingCall> pendingCalls_;
 
-        std::map<dht::Value::Id, PendingMessage> sentMessages_;
-        std::set<dht::Value::Id> treatedMessages_ {};
+		/**
+		* Incoming DHT calls that are not yet actual SIP calls.
+		*/
+		std::list<PendingCall> pendingSipCalls_;
+		std::set<dht::Value::Id> treatedCalls_{};
+		mutable std::mutex callsMutex_{};
 
-        std::string ringAccountId_ {};
-        std::string ringDeviceId_ {};
-        std::string ringDeviceName_ {};
-        std::string idPath_ {};
-        std::string cachePath_ {};
-        std::string dataPath_ {};
-        std::string ethPath_ {};
-        std::string ethAccount_ {};
+		std::map<dht::Value::Id, PendingMessage> sentMessages_;
+		std::set<dht::Value::Id> treatedMessages_{};
 
-        std::string archivePath_ {};
+		std::string ringAccountId_{};
+		std::string ringDeviceId_{};
+		std::string ringDeviceName_{};
+		std::string idPath_{};
+		std::string cachePath_{};
+		std::string dataPath_{};
+		std::string ethPath_{};
+		std::string ethAccount_{};
 
-        std::string receipt_ {};
-        std::vector<uint8_t> receiptSignature_ {};
-        dht::Value announceVal_;
+		std::string archivePath_{};
 
-        std::map<dht::InfoHash, TrustRequest> trustRequests_;
-        void loadTrustRequests();
-        void saveTrustRequests() const;
+		std::string receipt_{};
+		std::vector<uint8_t> receiptSignature_{};
+		dht::Value announceVal_;
 
-        std::map<dht::InfoHash, Contact> contacts_;
-        void loadContacts();
-        void saveContacts() const;
-        void updateContact(const dht::InfoHash&, const Contact&);
+		std::map<dht::InfoHash, TrustRequest> trustRequests_;
+		void loadTrustRequests();
+		void saveTrustRequests() const;
 
-        tls::TrustStore trust_;
+		std::map<dht::InfoHash, Contact> contacts_;
+		void loadContacts();
+		void saveContacts() const;
+		void updateContact(const dht::InfoHash&, const Contact&);
 
-        std::shared_ptr<dht::Value> announce_;
+		// Trust store with Ring account main certificate as the only CA
+		tls::TrustStore accountTrust_;
+		// Trust store for to match peer certificates
+		tls::TrustStore trust_;
 
-        /* this ring account associated devices */
-        std::map<dht::InfoHash, KnownDevice> knownDevices_;
+		std::shared_ptr<dht::Value> announce_;
 
-        /* tracked buddies presence */
-        std::recursive_mutex buddyInfoMtx;
-        std::map<dht::InfoHash, BuddyInfo> trackedBuddies_;
+		/* this ring account associated devices */
+		std::map<dht::InfoHash, KnownDevice> knownDevices_;
 
-        void loadAccount(const std::string& archive_password = {}, const std::string& archive_pin = {});
-        void loadAccountFromDHT(const std::string& archive_password, const std::string& archive_pin);
+		/* tracked buddies presence */
+		std::recursive_mutex buddyInfoMtx;
+		std::map<dht::InfoHash, BuddyInfo> trackedBuddies_;
 
-        bool hasCertificate() const;
-        bool hasPrivateKey() const;
-        bool useIdentity(const dht::crypto::Identity& id);
-        static bool needsMigration(const dht::crypto::Identity& id);
+		void loadAccount(const std::string& archive_password = {}, const std::string& archive_pin = {});
+		void loadAccountFromDHT(const std::string& archive_password, const std::string& archive_pin);
 
-        std::string makeReceipt(const dht::crypto::Identity& id);
-        void createRingDevice(const dht::crypto::Identity& id);
-        void initRingDevice(const ArchiveContent& a);
-        void migrateAccount(const std::string& pwd);
-        static bool updateCertificates(ArchiveContent& archive, dht::crypto::Identity& device);
+		bool hasCertificate() const;
+		bool hasPrivateKey() const;
+		bool useIdentity(const dht::crypto::Identity& id);
+		static bool needsMigration(const dht::crypto::Identity& id);
 
-        void createAccount(const std::string& archive_password);
-        std::vector<uint8_t> makeArchive(const ArchiveContent& content) const;
-        void saveArchive(const ArchiveContent& content, const std::string& pwd);
-        ArchiveContent readArchive(const std::string& pwd) const;
-        static ArchiveContent loadArchive(const std::vector<uint8_t>& data);
-        std::vector<std::pair<sockaddr_storage, socklen_t>> loadBootstrap() const;
+		std::string makeReceipt(const dht::crypto::Identity& id);
+		void createRingDevice(const dht::crypto::Identity& id);
+		void initRingDevice(const ArchiveContent& a);
+		void migrateAccount(const std::string& pwd, dht::crypto::Identity& device);
+		static bool updateCertificates(ArchiveContent& archive, dht::crypto::Identity& device);
 
-        static std::pair<std::string, std::string> saveIdentity(const dht::crypto::Identity id, const std::string& path, const std::string& name);
-        void saveNodes(const std::vector<dht::NodeExport>&) const;
-        void saveValues(const std::vector<dht::ValuesExport>&) const;
+		void createAccount(const std::string& archive_password, dht::crypto::Identity&& migrate);
+		std::vector<uint8_t> makeArchive(const ArchiveContent& content) const;
+		void saveArchive(const ArchiveContent& content, const std::string& pwd);
+		ArchiveContent readArchive(const std::string& pwd) const;
+		static ArchiveContent loadArchive(const std::vector<uint8_t>& data);
+		std::vector<std::pair<sockaddr_storage, socklen_t>> loadBootstrap() const;
 
-        void loadTreatedCalls();
-        void saveTreatedCalls() const;
+		static std::pair<std::string, std::string> saveIdentity(const dht::crypto::Identity id, const std::string& path, const std::string& name);
+		void saveNodes(const std::vector<dht::NodeExport>&) const;
+		void saveValues(const std::vector<dht::ValuesExport>&) const;
 
-        void loadTreatedMessages();
-        void saveTreatedMessages() const;
+		void loadTreatedCalls();
+		void saveTreatedCalls() const;
 
-        void loadKnownDevicesOld();
-        void loadKnownDevices();
-        void saveKnownDevices() const;
+		void loadTreatedMessages();
+		void saveTreatedMessages() const;
 
-        void replyToIncomingIceMsg(const std::shared_ptr<SIPCall>&,
-                                   const std::shared_ptr<IceTransport>&,
-                                   const dht::IceCandidates&,
-                                   const std::shared_ptr<dht::crypto::Certificate>&);
+		void loadKnownDevices();
+		void saveKnownDevices() const;
 
-        static tls::DhParams loadDhParams(const std::string path);
+		void replyToIncomingIceMsg(const std::shared_ptr<SIPCall>&,
+			const std::shared_ptr<IceTransport>&,
+			const dht::IceCandidates&,
+			const std::shared_ptr<dht::crypto::Certificate>&);
 
-        /**
-         * If privkeyPath_ is a valid private key file (PEM or DER),
-         * and certPath_ a valid certificate file, load and returns them.
-         * Otherwise, generate a new identity and returns it.
-         */
-        dht::crypto::Identity loadIdentity(const std::string& crt_path, const std::string& key_path, const std::string& key_pwd) const;
-        std::vector<dht::NodeExport> loadNodes() const;
-        std::vector<dht::ValuesExport> loadValues() const;
+		static tls::DhParams loadDhParams(const std::string path);
 
-        bool dhtPublicInCalls_ {true};
+		/**
+		* If privkeyPath_ is a valid private key file (PEM or DER),
+		* and certPath_ a valid certificate file, load and returns them.
+		* Otherwise, generate a new identity and returns it.
+		*/
+		dht::crypto::Identity loadIdentity(const std::string& crt_path, const std::string& key_path, const std::string& key_pwd) const;
+		std::vector<dht::NodeExport> loadNodes() const;
+		std::vector<dht::ValuesExport> loadValues() const;
 
-        /**
-         * DHT port preference
-         */
-        in_port_t dhtPort_ {};
+		bool dhtPublicInCalls_{ true };
 
-        /**
-         * DHT port actually used,
-         * this holds the actual port used for DHT, which may not be the port
-         * selected in the configuration in the case that UPnP is used and the
-         * configured port is already used by another client
-         */
-        UsedPort dhtPortUsed_ {};
+		/**
+		* DHT port preference
+		*/
+		in_port_t dhtPort_{};
 
-        /**
-         * The TLS settings, used only if tls is chosen as a sip transport.
-         */
-        void generateDhParams();
+		/**
+		* DHT port actually used,
+		* this holds the actual port used for DHT, which may not be the port
+		* selected in the configuration in the case that UPnP is used and the
+		* configured port is already used by another client
+		*/
+		UsedPort dhtPortUsed_{};
 
-        std::shared_future<tls::DhParams> dhParams_;
-        std::mutex dhParamsMtx_;
-        std::condition_variable dhParamsCv_;
+		/**
+		* The TLS settings, used only if tls is chosen as a sip transport.
+		*/
+		void generateDhParams();
 
-        bool allowPeersFromHistory_ {true};
-        bool allowPeersFromContact_ {true};
-        bool allowPeersFromTrusted_ {true};
+		std::shared_future<tls::DhParams> dhParams_;
+		std::mutex dhParamsMtx_;
+		std::condition_variable dhParamsCv_;
 
-        /**
-         * Optional: "received" parameter from VIA header
-         */
-        std::string receivedParameter_ {};
+		bool allowPeersFromHistory_{ true };
+		bool allowPeersFromContact_{ true };
+		bool allowPeersFromTrusted_{ true };
 
-        /**
-         * Optional: "rport" parameter from VIA header
-         */
-        int rPort_ {-1};
+		/**
+		* Optional: "received" parameter from VIA header
+		*/
+		std::string receivedParameter_{};
 
-        /**
-         * Optional: via_addr construct from received parameters
-         */
-        pjsip_host_port via_addr_ {};
+		/**
+		* Optional: "rport" parameter from VIA header
+		*/
+		int rPort_{ -1 };
 
-        char contactBuffer_[PJSIP_MAX_URL_SIZE] {};
-        pj_str_t contact_ {contactBuffer_, 0};
-        pjsip_transport* via_tp_ {nullptr};
+		/**
+		* Optional: via_addr construct from received parameters
+		*/
+		pjsip_host_port via_addr_{};
 
-        template <class... Args>
-        std::shared_ptr<IceTransport> createIceTransport(const Args&... args);
+		char contactBuffer_[PJSIP_MAX_URL_SIZE]{};
+		pj_str_t contact_{ contactBuffer_, 0 };
+		pjsip_transport* via_tp_{ nullptr };
 
-        void registerDhtAddress(IceTransport&);
-};
+		template <class... Args>
+		std::shared_ptr<IceTransport> createIceTransport(const Args&... args);
+
+		void registerDhtAddress(IceTransport&);
+
+		ContactsManager *contactsManager_;
+
+
+	};
 
 } // namespace ring


### PR DESCRIPTION
ringdht: Refactoring the ringaccount class. This creates a new class called contactsmanager which manages the accounts contacts.

This also transforms the contact struct into a new class called contact. This patch splits the responsabilty of managing the contacts list from the ringaccount class and gives it to a new class. Therefore, the ringaccount will call the contactmanager methods. This is introduces to improve the code quality. Due to this solution, the ringaccount class won't have too many responsabilities