### PR TITLE
SIPVoIPLink initializer need register_thread first befor pj_pool_create

### DIFF
--- a/src/sip/sipvoiplink.cpp
+++ b/src/sip/sipvoiplink.cpp
@@ -493,6 +493,7 @@ SIPVoIPLink::SIPVoIPLink() : pool_(nullptr, pj_pool_release)
     throw VoipLinkException(#ret " failed"); \
 } while (0)
 
+    sip_utils::register_thread();
     pj_caching_pool_init(&cp_, &pj_pool_factory_default_policy, 0);
     pool_.reset(pj_pool_create(&cp_.factory, PACKAGE, 64 * 1024, 4096, nullptr));
     if (!pool_)


### PR DESCRIPTION
Today I update all the libs of the ring project, build macOS and iOS version client for testing. When I run the client for macOS. Some error occurs:

**Client: ring-client-macos**

```
[0mAssertion failed: (!"Calling pjlib from unknown/external thread. You must " "register external threads with pj_thread_register() " "before calling any pjlib functions."), function pj_thread_this, file ../src/pj/os_core_unix.c, line 692.
```

**backtrace**

```
(lldb) bt
* thread #12, stop reason = signal SIGABRT
    frame #0: 0x00007fff620b6b86 libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x0000000101cb2884 libsystem_pthread.dylib`pthread_kill + 285
    frame #2: 0x00007fff620201c9 libsystem_c.dylib`abort + 127
    frame #3: 0x00007fff61fe8868 libsystem_c.dylib`__assert_rtn + 320
  * frame #4: 0x00000001024e0ba2 libring.0.dylib`pj_thread_this at os_core_unix.c:690
    frame #5: 0x00000001024e0704 libring.0.dylib`pj_mutex_lock(mutex=0x000000010691fcf0) at os_core_unix.c:1286
    frame #6: 0x00000001024ec5e9 libring.0.dylib`pj_lock_acquire(lock=0x000000010691fcc8) at lock.c:180
    frame #7: 0x00000001024f0094 libring.0.dylib`cpool_create_pool(pf=0x000000010691faa0, name="ring", initial_size=65536, increment_sz=4096, callback=0x0000000000000000) at pool_caching.c:131
    frame #8: 0x00000001024ef528 libring.0.dylib`pj_pool_create(f=0x000000010691faa0, name="ring", initial_size=65536, increment_size=4096, callback=0x0000000000000000) at pool_i.h:86
    frame #9: 0x0000000101f3fe4b libring.0.dylib`ring::SIPVoIPLink::SIPVoIPLink(this=0x000000010691fa98) at sipvoiplink.cpp:497
    frame #10: 0x0000000101f498e5 libring.0.dylib`ring::SIPVoIPLink::SIPVoIPLink(this=0x000000010691fa98) at sipvoiplink.cpp:490
    frame #11: 0x0000000101f55457 libring.0.dylib`std::__1::shared_ptr<ring::SIPVoIPLink> std::__1::shared_ptr<ring::SIPVoIPLink>::make_shared<>() [inlined] std::__1::__compressed_pair_elem<ring::SIPVoIPLink, 1, false>::__compressed_pair_elem(this=0x000000010691fa98) at memory:2089
    frame #12: 0x0000000101f5544b libring.0.dylib`std::__1::shared_ptr<ring::SIPVoIPLink> std::__1::shared_ptr<ring::SIPVoIPLink>::make_shared<>() [inlined] std::__1::__compressed_pair<std::__1::allocator<ring::SIPVoIPLink>, ring::SIPVoIPLink>::__compressed_pair<std::__1::allocator<ring::SIPVoIPLink>, true>(this=0x000000010691fa98, __t=0x000070000b052748) at memory:2187
```